### PR TITLE
fix: green status p2pool when node offline

### DIFF
--- a/src/app/panels/middle/p2pool/advanced.rs
+++ b/src/app/panels/middle/p2pool/advanced.rs
@@ -107,10 +107,10 @@ impl P2pool {
                             ui.add_space(SPACE);
                             slider_state_field(
                                 ui,
-                                "Log level [ 0-6 ]:",
+                                "Log level [ 2-6 ]:",
                                 P2POOL_LOG,
                                 &mut self.log_level,
-                                0..=6,
+                                2..=6,
                             );
                         })
                     });

--- a/src/app/panels/middle/p2pool/advanced.rs
+++ b/src/app/panels/middle/p2pool/advanced.rs
@@ -107,10 +107,10 @@ impl P2pool {
                             ui.add_space(SPACE);
                             slider_state_field(
                                 ui,
-                                "Log level [ 2-6 ]:",
+                                "Log level [ 0-6 ]:",
                                 P2POOL_LOG,
                                 &mut self.log_level,
-                                2..=6,
+                                0..=6,
                             );
                         })
                     });

--- a/src/helper/p2pool.rs
+++ b/src/helper/p2pool.rs
@@ -635,7 +635,7 @@ impl Helper {
                 }
 
                 // check if state must be changed based on local and p2p API
-                pub_api_lock.update_state(&process);
+                pub_api_lock.update_state(&mut process_lock);
 
                 // If more than 1 minute has passed, read the other API files.
                 let last_p2pool_request_expired =
@@ -1103,8 +1103,7 @@ impl PubP2poolApi {
         };
     }
     /// Check if all conditions are met to be alive or if something is wrong
-    fn update_state(&self, process: &Arc<Mutex<Process>>) {
-        let mut process = process.lock().unwrap();
+    fn update_state(&self, process: &mut Process) {
         if self.synchronised && self.node_connected && self.p2p_connected > 1 && self.height > 10 {
             process.state = ProcessState::Alive;
         } else {

--- a/src/helper/p2pool.rs
+++ b/src/helper/p2pool.rs
@@ -373,12 +373,6 @@ impl Helper {
                 } else {
                     &state.ip
                 };
-                // log level of p2pool must be minimum 2 so Gupaxx works correctly.
-                let log_level = if state.log_level < 2 {
-                    2
-                } else {
-                    state.log_level
-                };
                 args.push("--wallet".to_string());
                 args.push(state.address.clone()); // Wallet
                 args.push("--host".to_string());
@@ -388,7 +382,7 @@ impl Helper {
                 args.push("--zmq-port".to_string());
                 args.push(state.zmq.to_string()); // ZMQ
                 args.push("--loglevel".to_string());
-                args.push(log_level.to_string()); // Log Level
+                args.push(state.log_level.to_string()); // Log Level
                 args.push("--out-peers".to_string());
                 args.push(state.out_peers.to_string()); // Out Peers
                 args.push("--in-peers".to_string());

--- a/src/helper/tests.rs
+++ b/src/helper/tests.rs
@@ -8,6 +8,7 @@ mod test {
         p2pool::{PrivP2poolLocalApi, PrivP2poolNetworkApi},
         xvb::{priv_stats::RuntimeDonationLevel, priv_stats::RuntimeMode},
     };
+    use crate::human::HumanNumber;
     use crate::miscs::client;
 
     #[test]
@@ -291,7 +292,7 @@ Uptime         = 0h 2m 4s
         assert_eq!(p.monero_difficulty.to_string(), "300,000,000,000");
         assert_eq!(p.monero_hashrate.to_string(), "2.500 GH/s");
         assert_eq!(p.hash.to_string(), "asdf");
-        assert_eq!(p.height.to_string(), "1,234");
+        assert_eq!(HumanNumber::from_u32(p.height).to_string(), "1,234");
         assert_eq!(p.reward.to_u64(), 2345);
         assert_eq!(p.p2pool_difficulty.to_string(), "10,000,000");
         assert_eq!(p.p2pool_hashrate.to_string(), "1.000 MH/s");

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -81,12 +81,16 @@ pub const P2POOL_API_PATH_LOCAL: &str = r"local\stratum";
 pub const P2POOL_API_PATH_NETWORK: &str = r"network\stats";
 #[cfg(target_os = "windows")]
 pub const P2POOL_API_PATH_POOL: &str = r"pool\stats";
+#[cfg(target_family = "windows")]
+pub const P2POOL_API_PATH_P2P: &str = r"local\p2p";
 #[cfg(target_family = "unix")]
 pub const P2POOL_API_PATH_LOCAL: &str = "local/stratum";
 #[cfg(target_family = "unix")]
 pub const P2POOL_API_PATH_NETWORK: &str = "network/stats";
 #[cfg(target_family = "unix")]
 pub const P2POOL_API_PATH_POOL: &str = "pool/stats";
+#[cfg(target_family = "unix")]
+pub const P2POOL_API_PATH_P2P: &str = "local/p2p";
 pub const XMRIG_API_SUMMARY_URI: &str = "1/summary"; // The default relative URI of XMRig's API summary
 // pub const XMRIG_API_CONFIG_URI: &str = "1/config"; // The default relative URI of XMRig's API config
 // todo allow user to change the port of the http api for xmrig and xmrig-proxy

--- a/src/utils/regex.rs
+++ b/src/utils/regex.rs
@@ -277,6 +277,21 @@ pub fn contains_end_status(l: &str) -> bool {
     static LINE_SHARE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^Uptime         ").unwrap());
     LINE_SHARE.is_match(l)
 }
+// P2Pool
+/// if the node is disconnected
+/// this error will be present if log > 1 and Node is disconnected
+pub fn contains_zmq_failure(l: &str) -> bool {
+    static LINE_SHARE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(p2pool with offline node: failed: error Error (empty response)|ZMQReader failed to connect to|P2Pool Couldn't restart ZMQ reader: exception Operation cannot be accomplished in current state)").unwrap()
+    });
+    LINE_SHARE.is_match(l)
+}
+/// a way to detect that p2pool is alive
+pub fn contains_newchain_tip(l: &str) -> bool {
+    static LINE_SHARE: Lazy<Regex> = Lazy::new(|| Regex::new(r"new chain tip").unwrap());
+    LINE_SHARE.is_match(l)
+}
+
 //---------------------------------------------------------------------------------------------------- TEST
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
P2Pool state will change dynamically based on:
- Node connection,
- p2p network connection,
- synchronization

The user could always set log_level 1 or 0 in command args in advanced tab and break detection of errors.
Now detection is also using p2pool API files.
Need https://github.com/SChernykh/p2pool/commit/00b6dabc782ccd64acdc699d56bf842b96a35aad to have a release bundled in Gupaxx.

fix https://github.com/Cyrix126/gupaxx/issues/57