### PR TITLE
feat: P2Pool, add a checkbox to auto switch to local node when ready

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -623,6 +623,9 @@ impl App {
         info!("App Init | Setting saved [Tab]...");
         app.tab = app.state.gupax.tab;
 
+        // Set saved prefer local node to runtime
+        app.p2pool_api.lock().unwrap().prefer_local_node = app.state.p2pool.prefer_local_node;
+
         // Set saved Hero mode to runtime.
         debug!("Setting runtime_mode & runtime_manual_amount");
         // apply hero if simple mode saved with checkbox true, will let default to auto otherwise

--- a/src/app/panels/bottom.rs
+++ b/src/app/panels/bottom.rs
@@ -254,6 +254,7 @@ impl crate::app::App {
                                 &self.state.p2pool,
                                 &self.state.gupax.absolute_p2pool_path,
                                 self.gather_backup_hosts(),
+                                false,
                             );
                         }
                         ProcessName::Xmrig => {
@@ -324,6 +325,7 @@ impl crate::app::App {
                                 &self.state.p2pool,
                                 &self.state.gupax.absolute_p2pool_path,
                                 self.gather_backup_hosts(),
+                                false,
                             ),
 
                             ProcessName::Xmrig => {

--- a/src/app/panels/middle/p2pool/mod.rs
+++ b/src/app/panels/middle/p2pool/mod.rs
@@ -43,8 +43,10 @@ impl P2pool {
     ) {
         //---------------------------------------------------------------------------------------------------- [Simple] Console
         // debug!("P2Pool Tab | Rendering [Console]");
+        let mut api_lock = api.lock().unwrap();
+        // let mut prefer_local_node = api.lock().unwrap().prefer_local_node;
         egui::ScrollArea::vertical().show(ui, |ui| {
-            let text = &api.lock().unwrap().output;
+            let text = &api_lock.output;
             ui.group(|ui| {
                 console(ui, text);
                 if !self.simple {
@@ -74,7 +76,7 @@ impl P2pool {
             );
 
             if self.simple {
-                self.simple(ui, ping);
+                self.simple(ui, ping, &mut api_lock);
             } else {
                 self.advanced(ui, node_vec);
             }

--- a/src/disk/state.rs
+++ b/src/disk/state.rs
@@ -300,6 +300,7 @@ pub struct P2pool {
     pub rpc: String,
     pub zmq: String,
     pub selected_node: SelectedPoolNode,
+    pub prefer_local_node: bool,
 }
 
 // compatible for P2Pool and Xmrig/Proxy
@@ -618,6 +619,7 @@ impl Default for P2pool {
                 rpc: "18081".to_string(),
                 zmq_rig: "18083".to_string(),
             },
+            prefer_local_node: true,
         }
     }
 }

--- a/src/disk/tests.rs
+++ b/src/disk/tests.rs
@@ -83,7 +83,8 @@ mod test {
 			ip = "192.168.1.123"
 			rpc = "18089"
 			zmq = "18083"
-            
+            prefer_local_node = true
+
             [p2pool.selected_node]
             index = 0
             name = "Local Monero Node"

--- a/src/inits.rs
+++ b/src/inits.rs
@@ -208,6 +208,7 @@ pub fn init_auto(app: &mut App) {
                 &app.state.p2pool,
                 &app.state.gupax.absolute_p2pool_path,
                 backup_hosts,
+                false,
             );
         }
     } else {

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -384,6 +384,8 @@ pub const P2POOL_BACKUP_HOST_SIMPLE: &str = r#"Automatically switch to the other
 Note: you must ping the remote nodes or this feature will default to only using the currently selected node."#;
 pub const P2POOL_BACKUP_HOST_ADVANCED: &str =
     "Automatically switch to the other nodes in your list if the current one is down.";
+pub const P2POOL_AUTOSWITCH_LOCAL_NODE: &str =
+    "Automatically switch to the local node when it will be ready to be used.";
 pub const P2POOL_SELECT_FASTEST: &str = "Select the fastest remote Monero node";
 pub const P2POOL_SELECT_RANDOM: &str = "Select a random remote Monero node";
 pub const P2POOL_SELECT_LAST: &str = "Select the previous remote Monero node";


### PR DESCRIPTION
To enable the following feature: Start a P2pool node with a remote monero node while waiting for the local Node to sync.

No Save/ manual restart is needed to apply the checkbox new value.

With the checkbox enabled, P2pool will automatically restart to use the local Node once the later is ready.