### PR TITLE
feat: XvB, advanced tab, add checkbox to watch sidechain HR

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -626,6 +626,9 @@ impl App {
         // Set saved prefer local node to runtime
         app.p2pool_api.lock().unwrap().prefer_local_node = app.state.p2pool.prefer_local_node;
 
+        // Set saved choice of use of sidechain HR
+        app.xvb_api.lock().unwrap().use_p2pool_sidechain_hr = app.state.xvb.use_p2pool_sidechain_hr;
+
         // Set saved Hero mode to runtime.
         debug!("Setting runtime_mode & runtime_manual_amount");
         // apply hero if simple mode saved with checkbox true, will let default to auto otherwise

--- a/src/app/panels/middle/xvb.rs
+++ b/src/app/panels/middle/xvb.rs
@@ -23,7 +23,6 @@ use readable::num::Float;
 use readable::up::Uptime;
 use strum::EnumCount;
 
-use crate::XVB_MINING_ON_FIELD;
 use crate::app::panels::middle::common::console::console;
 use crate::app::panels::middle::common::header_tab::header_tab;
 use crate::app::panels::middle::common::state_edit_field::StateTextEdit;
@@ -42,6 +41,7 @@ use crate::utils::constants::{
     XVB_ROUND_TYPE_FIELD, XVB_TOKEN_LEN, XVB_URL_RULES, XVB_WINNER_FIELD,
 };
 use crate::utils::regex::Regexes;
+use crate::{XVB_MINING_ON_FIELD, XVB_P2POOL_BUFFER, XVB_SIDECHAIN};
 use crate::{
     constants::{BYTES_XVB, SPACE},
     utils::constants::XVB_URL,
@@ -107,6 +107,7 @@ impl crate::disk::state::Xvb {
     });
         ui.add_space(SPACE);
          // --------------------------- XVB Advanced -----------------------------------------
+                        let text_height = height_txt_before_button(ui, &TextStyle::Heading) * 1.4;
                 ScrollArea::horizontal().id_salt("horizontal").show(ui, |ui| {
          if !self.simple {
 
@@ -116,7 +117,6 @@ impl crate::disk::state::Xvb {
                         ui.style_mut().override_text_valign = Some(Align::Center);
                         ui.set_height(0.0);
                         ui.set_height(0.0);
-                        let text_height = height_txt_before_button(ui, &TextStyle::Heading) * 1.4;
                         egui::ComboBox::from_label("").height(XvbMode::COUNT as f32 * (ui.text_style_height(&TextStyle::Button) + (ui.spacing().button_padding.y * 2.0) + ui.spacing().item_spacing.y))
                         .selected_text(self.mode.to_string())
                         .show_ui(ui, |ui| {
@@ -238,16 +238,25 @@ impl crate::disk::state::Xvb {
             api.lock().unwrap().stats_priv.runtime_manual_amount = self.manual_amount_raw;
          ui.add_space(SPACE);
 
+         ui.horizontal(|ui|{
             // allow user to modify the buffer for p2pool
             // button
             ui.add_sized(
-                [ui.available_width() * 0.8, height_txt_before_button(ui, &TextStyle::Button)],
+                [0.0 , text_height],
                 egui::Slider::new(&mut self.p2pool_buffer, -100..=100)
                 .text("% P2Pool Buffer" )
-            ).on_hover_text("Set the % amount of additional HR to send to p2pool. Will reduce (if positive) or augment (if negative) the chances to miss the p2pool window");
-        }
+            ).on_hover_text(XVB_P2POOL_BUFFER);
 
          ui.add_space(SPACE);
+         // p2pool sidechain HR or stratum data
+            if ui.add_sized(
+                [0.0, text_height],
+                egui::Checkbox::new(&mut self.use_p2pool_sidechain_hr, "Watch P2Pool Sidechain HR")).on_hover_text(XVB_SIDECHAIN).clicked() {
+                api.lock().unwrap().use_p2pool_sidechain_hr = self.use_p2pool_sidechain_hr;
+            }
+         });
+        }
+
         // need to warn the user if no address is set in p2pool tab
         if !Regexes::addr_ok(address) {
             debug!("XvB Tab | Rendering warning text");

--- a/src/disk/state.rs
+++ b/src/disk/state.rs
@@ -468,6 +468,7 @@ pub struct Xvb {
     pub manual_donation_level: ManualDonationLevel,
     pub manual_donation_metric: ManualDonationMetric,
     pub p2pool_buffer: i8,
+    pub use_p2pool_sidechain_hr: bool,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize, Default, EnumCount, EnumIter)]
@@ -680,6 +681,7 @@ impl Default for Xvb {
             manual_donation_level: Default::default(),
             manual_donation_metric: Default::default(),
             p2pool_buffer: 25,
+            use_p2pool_sidechain_hr: false,
         }
     }
 }

--- a/src/helper/xvb/algorithm.rs
+++ b/src/helper/xvb/algorithm.rs
@@ -135,6 +135,7 @@ impl<'a> Algorithm<'a> {
         xp_alive: bool,
         p2pool_buffer: i8,
     ) -> Self {
+        let use_sidechain_hr = gui_api_xvb.lock().unwrap().use_p2pool_sidechain_hr;
         let hashrate_xmrig = current_controllable_hr(xp_alive, gui_api_xp, gui_api_xmrig);
 
         let address = state_p2pool.address.clone();
@@ -148,7 +149,13 @@ impl<'a> Algorithm<'a> {
             .clone();
         let runtime_amount = gui_api_xvb.lock().unwrap().stats_priv.runtime_manual_amount;
 
-        let p2pool_total_hashrate = gui_api_p2pool.lock().unwrap().sidechain_ehr;
+        let p2pool_total_hashrate = if use_sidechain_hr {
+            gui_api_p2pool.lock().unwrap().sidechain_ehr
+        } else if gui_api_p2pool.lock().unwrap().hashrate_1h > 0 {
+            gui_api_p2pool.lock().unwrap().hashrate_1h as f32
+        } else {
+            gui_api_p2pool.lock().unwrap().hashrate_15m as f32
+        };
 
         let p2pool_avg_last_hour_hashrate = Self::calc_last_hour_avg_hash_rate(
             &gui_api_xvb.lock().unwrap().p2pool_sent_last_hour_samples,

--- a/src/helper/xvb/mod.rs
+++ b/src/helper/xvb/mod.rs
@@ -441,6 +441,9 @@ pub struct PubXvbApi {
     // will be updated by output of xmrig.
     // could also be retrieved by fetching current config.
     pub current_node: Option<XvbNode>,
+    // Instead of watching stratum data that will account for HR sent only on this p2pool node,
+    // Take the value of estimated HR that will account for external miners mininf on the same address.
+    pub use_p2pool_sidechain_hr: bool,
 }
 #[derive(Debug, Clone)]
 pub struct SamplesAverageHour(BoundedVecDeque<f32>);
@@ -485,6 +488,7 @@ impl PubXvbApi {
                 &mut gui_api.p2pool_sent_last_hour_samples,
             ),
             xvb_sent_last_hour_samples: std::mem::take(&mut gui_api.xvb_sent_last_hour_samples),
+            use_p2pool_sidechain_hr: std::mem::take(&mut gui_api.use_p2pool_sidechain_hr),
             ..pub_api.clone()
         };
     }
@@ -857,7 +861,7 @@ fn reset_data_xvb(pub_api: &Arc<Mutex<PubXvbApi>>, gui_api: &Arc<Mutex<PubXvbApi
     let runtime_mode = mem::take(&mut gui_api.lock().unwrap().stats_priv.runtime_mode);
     let runtime_manual_amount =
         mem::take(&mut gui_api.lock().unwrap().stats_priv.runtime_manual_amount);
-
+    let use_sidechain_hr = mem::take(&mut gui_api.lock().unwrap().use_p2pool_sidechain_hr);
     // let output = mem::take(&mut gui_api.lock().unwrap().output);
     *pub_api.lock().unwrap() = PubXvbApi::new();
     *gui_api.lock().unwrap() = PubXvbApi::new();
@@ -868,6 +872,8 @@ fn reset_data_xvb(pub_api: &Arc<Mutex<PubXvbApi>>, gui_api: &Arc<Mutex<PubXvbApi
     gui_api.lock().unwrap().stats_priv.runtime_manual_amount = runtime_manual_amount;
     // message while starting must be preserved.
     // pub_api.lock().unwrap().output = output;
+    // to not lose information about the use of sidechain hr
+    gui_api.lock().unwrap().use_p2pool_sidechain_hr = use_sidechain_hr;
 }
 // print date time to console output in same format than xmrig
 fn update_indicator_algo(

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -156,7 +156,13 @@ pub const XVB_FAILED: &str = "XvB process is misconfigured or the XvB node is of
 pub const XVB_MIDDLE: &str = "XvB is in the middle of (re)starting/stopping";
 pub const XVB_NOT_CONFIGURED: &str = "You need to insert an existent token before starting XvB";
 pub const XVB_PUBLIC_ONLY: &str = "XvB process is started only to get public stats.";
-
+pub const XVB_SIDECHAIN: &str = "
+If checked:\n
+The algorithm will watch the estimated HR given for your address on the P2Pool network. This way, it will take into account external miners that are mining on P2Pool for your address without using the P2Pool node of Gupaxx. This estimation can be imprecised.\n
+If unchecked (default):\n
+The algorithm will watch the HR estimated by the stratum data of the p2pool node, which is more accurate but will only take into account the miners that are using your P2Pool node.
+";
+pub const XVB_P2POOL_BUFFER: &str = "Set the % amount of additional HR to send to p2pool. Will reduce (if positive) or augment (if negative) the chances to miss the p2pool window";
 // This is the typical space added when using
 // [ui.separator()] or [ui.group()]
 // Used for subtracting the width/height so


### PR DESCRIPTION
Watch by default the HR of stratum data to know the HR sent to p2pool.
If enabled, watch the HR of side chain for the address instead.