### PR TITLE
feat: do not ask for sudo prompt when not needed

### DIFF
--- a/src/app/panels/bottom.rs
+++ b/src/app/panels/bottom.rs
@@ -258,7 +258,7 @@ impl crate::app::App {
                             );
                         }
                         ProcessName::Xmrig => {
-                            if cfg!(windows) {
+                            if cfg!(windows) || !Helper::password_needed() {
                                 Helper::restart_xmrig(
                                     &self.helper,
                                     &self.state.xmrig,
@@ -329,14 +329,14 @@ impl crate::app::App {
                             ),
 
                             ProcessName::Xmrig => {
-                                if cfg!(windows) {
+                                if cfg!(windows) || !Helper::password_needed() {
                                     Helper::start_xmrig(
                                         &self.helper,
                                         &self.state.xmrig,
                                         &self.state.gupax.absolute_xmrig_path,
                                         Arc::clone(&self.sudo),
                                     );
-                                } else if cfg!(unix) {
+                                } else {
                                     self.sudo.lock().unwrap().signal = ProcessSignal::Start;
                                     self.error_state.ask_sudo(&self.sudo);
                                 }

--- a/src/inits.rs
+++ b/src/inits.rs
@@ -230,7 +230,7 @@ pub fn init_auto(app: &mut App) {
             warn!(
                 "Gupaxx | Xmrig instance is already running outside of Gupaxx ! Skipping auto-node..."
             );
-        } else if cfg!(windows) {
+        } else if cfg!(windows) || !Helper::password_needed() {
             Helper::start_xmrig(
                 &app.helper,
                 &app.state.xmrig,


### PR DESCRIPTION
sudo password are not needed when:
- the user is granted permission to use sudo without password in visudo
- the sudo cache still grant the user privileges after having entered the password