### PR TITLE
feat: handling custom values from processes that depends on them + fixes

### DIFF
--- a/src/app/panels/bottom.rs
+++ b/src/app/panels/bottom.rs
@@ -169,7 +169,7 @@ impl crate::app::App {
                     ProcessName::Xvb => XVB_FAILED,
                 }
             }
-            Syncing | NotMining | OfflineNodesAll => {
+            Syncing | NotMining | OfflinePoolsAll => {
                 color = ORANGE;
                 match process.name {
                     ProcessName::Node => NODE_SYNCING,
@@ -262,8 +262,9 @@ impl crate::app::App {
                             Helper::restart_p2pool(
                                 &self.helper,
                                 &self.state.p2pool,
+                                &self.state.node,
                                 &self.state.gupax.absolute_p2pool_path,
-                                self.gather_backup_hosts(),
+                                self.backup_hosts.clone(),
                                 false,
                             );
                         }
@@ -272,6 +273,8 @@ impl crate::app::App {
                                 Helper::restart_xmrig(
                                     &self.helper,
                                     &self.state.xmrig,
+                                    &self.state.p2pool,
+                                    &self.state.xmrig_proxy,
                                     &self.state.gupax.absolute_xmrig_path,
                                     Arc::clone(&self.sudo),
                                 );
@@ -284,7 +287,7 @@ impl crate::app::App {
                             Helper::restart_xp(
                                 &self.helper,
                                 &self.state.xmrig_proxy,
-                                &self.state.xmrig,
+                                &self.state.p2pool,
                                 &self.state.gupax.absolute_xp_path,
                             );
                         }
@@ -333,8 +336,9 @@ impl crate::app::App {
                             ProcessName::P2pool => Helper::start_p2pool(
                                 &self.helper,
                                 &self.state.p2pool,
+                                &self.state.node,
                                 &self.state.gupax.absolute_p2pool_path,
-                                self.gather_backup_hosts(),
+                                self.backup_hosts.clone(),
                                 false,
                             ),
 
@@ -343,6 +347,8 @@ impl crate::app::App {
                                     Helper::start_xmrig(
                                         &self.helper,
                                         &self.state.xmrig,
+                                        &self.state.p2pool,
+                                        &self.state.xmrig_proxy,
                                         &self.state.gupax.absolute_xmrig_path,
                                         Arc::clone(&self.sudo),
                                     );
@@ -355,7 +361,7 @@ impl crate::app::App {
                             ProcessName::XmrigProxy => Helper::start_xp(
                                 &self.helper,
                                 &self.state.xmrig_proxy,
-                                &self.state.xmrig,
+                                &self.state.p2pool,
                                 &self.state.gupax.absolute_xp_path,
                             ),
                             ProcessName::Xvb => Helper::start_xvb(

--- a/src/app/panels/middle/mod.rs
+++ b/src/app/panels/middle/mod.rs
@@ -101,8 +101,8 @@ impl crate::app::App {
                     );
                 }
                 Tab::P2pool => {
+                    let (rpc_port, zmq_port) = self.state.node.ports();
                     debug!("App | Entering [P2Pool] Tab");
-                    let backup_hosts = self.gather_backup_hosts();
                     crate::disk::state::P2pool::show(
                         &mut self.state.p2pool,
                         &mut self.node_vec,
@@ -113,8 +113,10 @@ impl crate::app::App {
                         &mut self.p2pool_stdin,
                         ctx,
                         ui,
-                        backup_hosts,
+                        self.backup_hosts.clone(),
                         &self.state.gupax.absolute_p2pool_path,
+                        zmq_port,
+                        rpc_port,
                     );
                 }
                 Tab::Xmrig => {
@@ -127,6 +129,7 @@ impl crate::app::App {
                         &mut self.xmrig_stdin,
                         ctx,
                         ui,
+                        self.state.p2pool.stratum_port(),
                     );
                 }
                 Tab::XmrigProxy => {
@@ -138,6 +141,7 @@ impl crate::app::App {
                         &self.xmrig_proxy_api,
                         &mut self.xmrig_proxy_stdin,
                         ui,
+                        self.state.p2pool.stratum_port(),
                     );
                 }
                 Tab::Xvb => {

--- a/src/app/panels/middle/p2pool/advanced.rs
+++ b/src/app/panels/middle/p2pool/advanced.rs
@@ -49,6 +49,9 @@ impl P2pool {
                             if !self.zmq_port_field(ui) {
                                 incorrect_input = false;
                             }
+                            if !self.stratum_port_field(ui) {
+                                incorrect_input = false;
+                            }
                         });
                         list_poolnode(
                             ui,
@@ -165,5 +168,20 @@ impl P2pool {
             .help_msg(P2POOL_NODE_IP)
             .validations(&[|x| REGEXES.ipv4.is_match(x), |x| REGEXES.domain.is_match(x)])
             .build(ui, &mut self.ip)
+    }
+
+    /// TODO: find a better solution to handle settings that are not String ?
+    fn stratum_port_field(&mut self, ui: &mut Ui) -> bool {
+        let mut port = self.stratum_port.to_string();
+        let valid = StateTextEdit::new(ui)
+            .description("STRATUM PORT")
+            .max_ch(5)
+            .help_msg(HELP_STRATUM_PORT)
+            .validations(&[|x| REGEXES.port.is_match(x)])
+            .build(ui, &mut port);
+        if let Ok(port) = port.parse() {
+            self.stratum_port = port;
+        }
+        valid
     }
 }

--- a/src/app/panels/middle/p2pool/mod.rs
+++ b/src/app/panels/middle/p2pool/mod.rs
@@ -44,6 +44,8 @@ impl P2pool {
         ui: &mut egui::Ui,
         backup_nodes: Option<Vec<PoolNode>>,
         path: &Path,
+        local_node_zmq_port: u16,
+        local_node_rpc_port: u16,
     ) {
         //---------------------------------------------------------------------------------------------------- [Simple] Console
         // debug!("P2Pool Tab | Rendering [Console]");
@@ -72,10 +74,20 @@ impl P2pool {
                 }
             });
             if !self.simple {
-                let default_args_simple =
-                    self.start_options(path, &backup_nodes, StartOptionsMode::Simple);
-                let default_args_advanced =
-                    self.start_options(path, &backup_nodes, StartOptionsMode::Advanced);
+                let default_args_simple = self.start_options(
+                    path,
+                    &backup_nodes,
+                    StartOptionsMode::Simple,
+                    local_node_zmq_port,
+                    local_node_rpc_port,
+                );
+                let default_args_advanced = self.start_options(
+                    path,
+                    &backup_nodes,
+                    StartOptionsMode::Advanced,
+                    local_node_zmq_port,
+                    local_node_rpc_port,
+                );
                 start_options_field(
                     ui,
                     &mut self.arguments,

--- a/src/app/panels/middle/status/processes.rs
+++ b/src/app/panels/middle/status/processes.rs
@@ -7,6 +7,7 @@ use crate::helper::node::PubNodeApi;
 use crate::helper::p2pool::{ImgP2pool, PubP2poolApi};
 use crate::helper::xrig::xmrig::{ImgXmrig, PubXmrigApi};
 use crate::helper::xrig::xmrig_proxy::PubXmrigProxyApi;
+use crate::helper::xvb::nodes::Pool;
 use crate::helper::xvb::{PubXvbApi, rounds::XvbRound};
 use crate::helper::{ProcessName, Sys};
 
@@ -285,7 +286,7 @@ fn xmrig_proxy(
 
         ui.label(RichText::new("Pool").underline().color(BONE))
             .on_hover_text(STATUS_XMRIG_PROXY_POOL);
-        ui.label(api.node.to_string());
+        ui.label(api.pool.as_ref().unwrap_or(&Pool::Unknown).to_string());
         drop(api);
     });
 }
@@ -337,7 +338,7 @@ fn xmrig(
         ));
         ui.label(RichText::new("Pool").underline().color(BONE))
             .on_hover_text(STATUS_XMRIG_POOL);
-        ui.label(api.node.to_string());
+        ui.label(api.pool.as_ref().unwrap_or(&Pool::Unknown).to_string());
         ui.label(RichText::new("Threads").underline().color(BONE))
             .on_hover_text(STATUS_XMRIG_THREADS);
         ui.label(format!(

--- a/src/app/panels/middle/xmrig.rs
+++ b/src/app/panels/middle/xmrig.rs
@@ -46,6 +46,7 @@ impl Xmrig {
         buffer: &mut String,
         _ctx: &egui::Context,
         ui: &mut egui::Ui,
+        p2pool_stratum_port: u16,
     ) {
         header_tab(
             ui,
@@ -72,8 +73,10 @@ impl Xmrig {
             });
             if !self.simple {
                 debug!("XMRig Tab | Rendering [Arguments]");
-                let default_args_simple = self.start_options(StartOptionsMode::Simple);
-                let default_args_advanced = self.start_options(StartOptionsMode::Advanced);
+                let default_args_simple =
+                    self.start_options(StartOptionsMode::Simple, p2pool_stratum_port);
+                let default_args_advanced =
+                    self.start_options(StartOptionsMode::Advanced, p2pool_stratum_port);
                 start_options_field(
                     ui,
                     &mut self.arguments,

--- a/src/app/panels/middle/xvb.rs
+++ b/src/app/panels/middle/xvb.rs
@@ -271,7 +271,7 @@ impl crate::disk::state::Xvb {
             ui.add_enabled_ui(is_alive, |ui| {
                 let api = &api.lock().unwrap();
                 let priv_stats = &api.stats_priv;
-                let current_node = &api.current_node;
+                let current_node = &api.current_pool;
                 let style_height = ui.text_style_height(&TextStyle::Body);
 
         let width_column = ui.text_style_height(&TextStyle::Body) * 12.0;
@@ -327,7 +327,7 @@ if priv_stats.win_current {
                                             .map_or("No where".to_string(), |n| n.to_string()),
                                     )
                                     .on_hover_text_at_pointer(&priv_stats.msg_indicator);
-                                    ui.label(Uptime::from(priv_stats.time_switch_node).to_string())
+                                    ui.label(Uptime::from(priv_stats.time_switch_pool).to_string())
                                         .on_hover_text_at_pointer(&priv_stats.msg_indicator)
                                 })
                             });

--- a/src/app/panels/quit_error.rs
+++ b/src/app/panels/quit_error.rs
@@ -324,6 +324,8 @@ impl crate::app::App {
                                         self.sudo.clone(),
                                         &self.helper.clone(),
                                         &self.state.xmrig,
+                                        &self.state.p2pool,
+                                        &self.state.xmrig_proxy,
                                         &self.state.gupax.absolute_xmrig_path,
                                     );
                                 }

--- a/src/disk/tests.rs
+++ b/src/disk/tests.rs
@@ -87,6 +87,7 @@ mod test {
 			zmq = "18083"
             prefer_local_node = true
             console_height = 360
+            stratum_port = 3333
 
             [p2pool.selected_node]
             index = 0

--- a/src/helper/node.rs
+++ b/src/helper/node.rs
@@ -187,6 +187,8 @@ impl Helper {
         } else {
             StartOptionsMode::Advanced
         };
+        let (rpc_port, zmq_port) = state.ports();
+        *helper.lock().unwrap().img_node.lock().unwrap() = ImgNode { rpc_port, zmq_port };
         let args = Self::build_node_args(state, mode);
 
         // Print arguments & user settings to console
@@ -457,5 +459,19 @@ impl PrivNodeApi {
             }
         }
         Ok(private)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct ImgNode {
+    pub rpc_port: u16,
+    pub zmq_port: u16,
+}
+
+impl Default for ImgNode {
+    fn default() -> Self {
+        Self {
+            rpc_port: 18081,
+            zmq_port: 18083,
+        }
     }
 }

--- a/src/helper/tests.rs
+++ b/src/helper/tests.rs
@@ -18,8 +18,10 @@
 #[cfg(test)]
 mod test {
 
-    use crate::disk::state::StartOptionsMode;
-    use crate::helper::xrig::xmrig_proxy::PubXmrigProxyApi;
+    use crate::disk::state::{StartOptionsMode, XmrigProxy};
+    use crate::helper::p2pool::ImgP2pool;
+    use crate::helper::xrig::xmrig::ImgXmrig;
+    use crate::helper::xrig::xmrig_proxy::{ImgProxy, PubXmrigProxyApi};
     use crate::helper::xvb::algorithm::Algorithm;
     use crate::helper::{
         Helper, Process, ProcessName, ProcessState,
@@ -266,6 +268,20 @@ Uptime         = 0h 2m 4s
             "".to_string(),
             PathBuf::new(),
         )));
+        let process_p2pool = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            "".to_string(),
+            PathBuf::new(),
+        )));
+        let process_xp = Arc::new(Mutex::new(Process::new(
+            ProcessName::XmrigProxy,
+            "".to_string(),
+            PathBuf::new(),
+        )));
+        let img_p2pool = Arc::new(Mutex::new(ImgP2pool::new()));
+        let img_proxy = Arc::new(Mutex::new(ImgProxy::new()));
+        let proxy_state = XmrigProxy::default();
+        let p2pool_state = P2pool::default();
 
         process.lock().unwrap().state = ProcessState::Alive;
         PubXmrigApi::update_from_output(
@@ -274,6 +290,12 @@ Uptime         = 0h 2m 4s
             &output_pub,
             elapsed,
             &mut process.lock().unwrap(),
+            &process_p2pool.lock().unwrap(),
+            &process_xp.lock().unwrap(),
+            &img_proxy,
+            &img_p2pool,
+            &proxy_state,
+            &p2pool_state,
         );
         println!("{:#?}", process);
         assert!(process.lock().unwrap().state == ProcessState::NotMining);
@@ -287,6 +309,12 @@ Uptime         = 0h 2m 4s
             &output_pub,
             elapsed,
             &mut process.lock().unwrap(),
+            &process_p2pool.lock().unwrap(),
+            &process_xp.lock().unwrap(),
+            &img_proxy,
+            &img_p2pool,
+            &proxy_state,
+            &p2pool_state,
         );
         assert!(process.lock().unwrap().state == ProcessState::Alive);
     }
@@ -516,6 +544,14 @@ Uptime         = 0h 2m 4s
         let gui_api_p2pool = Arc::new(Mutex::new(PubP2poolApi::new()));
         let token_xmrig = "12345678";
         let state_p2pool = P2pool::default();
+        let proxy_img = Arc::new(Mutex::new(ImgProxy::new()));
+        let p2pool_img = Arc::new(Mutex::new(ImgP2pool::new()));
+        let xmrig_img = Arc::new(Mutex::new(ImgXmrig::new()));
+        let p2pool_process = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            String::new(),
+            PathBuf::new(),
+        )));
         let time_donated = Arc::new(Mutex::new(u32::default()));
         let rig = "test_rig";
         let xp_alive = false;
@@ -540,6 +576,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 1000.0);
@@ -560,6 +600,14 @@ Uptime         = 0h 2m 4s
         let xp_alive = false;
         let share = 1;
         let p2pool_buffer = 5;
+        let proxy_img = Arc::new(Mutex::new(ImgProxy::new()));
+        let p2pool_img = Arc::new(Mutex::new(ImgP2pool::new()));
+        let xmrig_img = Arc::new(Mutex::new(ImgXmrig::new()));
+        let p2pool_process = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            String::new(),
+            PathBuf::new(),
+        )));
 
         gui_api_xmrig.lock().unwrap().hashrate_raw_15m = 10000.0;
         gui_api_xvb.lock().unwrap().stats_priv.runtime_mode = RuntimeMode::ManualP2pool;
@@ -579,6 +627,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 9000.0);
@@ -599,6 +651,14 @@ Uptime         = 0h 2m 4s
         let xp_alive = false;
         let share = 1;
         let p2pool_buffer = 5;
+        let proxy_img = Arc::new(Mutex::new(ImgProxy::new()));
+        let p2pool_img = Arc::new(Mutex::new(ImgP2pool::new()));
+        let xmrig_img = Arc::new(Mutex::new(ImgXmrig::new()));
+        let p2pool_process = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            String::new(),
+            PathBuf::new(),
+        )));
 
         gui_api_xmrig.lock().unwrap().hashrate_raw_15m = 10000.0;
         gui_api_xvb.lock().unwrap().stats_priv.runtime_mode = RuntimeMode::ManualDonationLevel;
@@ -623,6 +683,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 1000.0);
@@ -643,6 +707,14 @@ Uptime         = 0h 2m 4s
         let xp_alive = false;
         let share = 1;
         let p2pool_buffer = 5;
+        let proxy_img = Arc::new(Mutex::new(ImgProxy::new()));
+        let p2pool_img = Arc::new(Mutex::new(ImgP2pool::new()));
+        let xmrig_img = Arc::new(Mutex::new(ImgXmrig::new()));
+        let p2pool_process = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            String::new(),
+            PathBuf::new(),
+        )));
 
         gui_api_p2pool.lock().unwrap().p2pool_difficulty_u64 = 9_000_000;
         gui_api_xmrig.lock().unwrap().hashrate_raw_15m = 20000.0;
@@ -662,6 +734,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 10000.0);
@@ -684,6 +760,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 1000.0);
@@ -704,6 +784,14 @@ Uptime         = 0h 2m 4s
         let xp_alive = false;
         let share = 1;
         let p2pool_buffer = 5;
+        let proxy_img = Arc::new(Mutex::new(ImgProxy::new()));
+        let p2pool_img = Arc::new(Mutex::new(ImgP2pool::new()));
+        let xmrig_img = Arc::new(Mutex::new(ImgXmrig::new()));
+        let p2pool_process = Arc::new(Mutex::new(Process::new(
+            ProcessName::P2pool,
+            String::new(),
+            PathBuf::new(),
+        )));
 
         gui_api_p2pool.lock().unwrap().p2pool_difficulty_u64 = 95_000_000;
         gui_api_xmrig.lock().unwrap().hashrate_raw_15m = 20000.0;
@@ -724,6 +812,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 15382.1);
@@ -744,6 +836,10 @@ Uptime         = 0h 2m 4s
             rig,
             xp_alive,
             p2pool_buffer,
+            &proxy_img,
+            &xmrig_img,
+            &p2pool_img,
+            &p2pool_process,
         );
 
         assert_eq!(algo.stats.target_donation_hashrate, 20000.0);
@@ -763,6 +859,8 @@ Uptime         = 0h 2m 4s
             Path::new(""),
             &None,
             false,
+            18083,
+            18081,
             StartOptionsMode::Custom,
         );
         assert_eq!(

--- a/src/helper/xrig/xmrig_proxy.rs
+++ b/src/helper/xrig/xmrig_proxy.rs
@@ -21,6 +21,7 @@ use reqwest::header::AUTHORIZATION;
 use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
+use std::time::Duration;
 use std::{
     path::Path,
     sync::{Arc, Mutex},
@@ -29,36 +30,42 @@ use std::{
 };
 use tokio::spawn;
 
-use crate::disk::state::StartOptionsMode;
+use crate::disk::state::{P2pool, StartOptionsMode, XmrigProxy};
+use crate::helper::p2pool::ImgP2pool;
+use crate::helper::xrig::current_api_url_xrig;
 use crate::human::{HumanNumber, HumanTime};
 use crate::miscs::client;
 use crate::{
-    GUPAX_VERSION_UNDERSCORE, UNKNOWN_DATA,
-    disk::state::Xmrig,
+    GUPAX_VERSION_UNDERSCORE,
     helper::{
         Helper, Process, ProcessName, ProcessSignal, ProcessState, check_died, check_user_input,
         signal_end, sleep_end_loop,
         xrig::update_xmrig_config,
-        xvb::{PubXvbApi, nodes::XvbNode},
+        xvb::{PubXvbApi, nodes::Pool},
     },
     macros::{arc_mut, sleep},
     miscs::output_console,
-    regex::{XMRIG_REGEX, contains_timeout, contains_usepool, detect_new_node_xmrig},
+    regex::{XMRIG_REGEX, contains_timeout, contains_usepool, detect_pool_xmrig},
 };
-use crate::{NO_POOL, XMRIG_CONFIG_URL, XMRIG_PROXY_SUMMARY_URL};
+use crate::{PROXY_API_PORT_DEFAULT, PROXY_PORT_DEFAULT, XMRIG_API_SUMMARY_ENDPOINT};
 
-use super::xmrig::PubXmrigApi;
+use super::xmrig::{ImgXmrig, PubXmrigApi};
 impl Helper {
     // Takes in some [State/XmrigProxy] and parses it to build the actual command arguments.
     // Returns the [Vec] of actual arguments,
     #[cold]
     #[inline(never)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn read_pty_xp(
         output_parse: Arc<Mutex<String>>,
         output_pub: Arc<Mutex<String>>,
         reader: Box<dyn std::io::Read + Send>,
         process_xvb: Arc<Mutex<Process>>,
         pub_api_xvb: &Arc<Mutex<PubXvbApi>>,
+        process_p2pool: Arc<Mutex<Process>>,
+        p2pool_state: &P2pool,
+        p2pool_img: &Arc<Mutex<ImgP2pool>>,
+        proxy_state: &XmrigProxy,
     ) {
         use std::io::BufRead;
         let mut stdout = std::io::BufReader::new(reader).lines();
@@ -86,35 +93,47 @@ impl Helper {
             // only switch nodes of XvB if XvB process is used
             if process_xvb.lock().unwrap().is_alive() {
                 if contains_timeout(&line) {
-                    let current_node = pub_api_xvb.lock().unwrap().current_node;
+                    let current_node = pub_api_xvb.lock().unwrap().current_pool.clone();
                     if let Some(current_node) = current_node {
                         // updating current node to None, will stop sending signal of FailedNode until new node is set
                         // send signal to update node.
                         warn!(
                             "XMRig-Proxy PTY Parse | node is offline, sending signal to update nodes."
                         );
-                        if current_node != XvbNode::P2pool {
+                        if current_node
+                            != Pool::P2pool(p2pool_state.current_port(
+                                &process_p2pool.lock().unwrap(),
+                                &p2pool_img.lock().unwrap(),
+                            ))
+                        {
                             process_xvb.lock().unwrap().signal =
-                                ProcessSignal::UpdateNodes(current_node);
+                                ProcessSignal::UpdatePools(current_node);
                         }
-                        pub_api_xvb.lock().unwrap().current_node = None;
+                        pub_api_xvb.lock().unwrap().current_pool = None;
                     }
                 }
                 if contains_usepool(&line) {
                     info!("XMRig-Proxy PTY Parse | new pool detected");
                     // need to update current node because it was updated.
                     // if custom node made by user, it is not supported because algo is deciding which node to use.
-
-                    let node = detect_new_node_xmrig(&line);
+                    // the state of the process we are in will always be in sync with the image of settings with started with because it is cloned with the start of the process.
+                    let node = detect_pool_xmrig(
+                        &line,
+                        proxy_state.bind_port(),
+                        p2pool_state.current_port(
+                            &process_p2pool.lock().unwrap(),
+                            &p2pool_img.lock().unwrap(),
+                        ),
+                    );
                     if node.is_none() {
                         warn!(
                             "XMRig-Proxy PTY Parse | node is not understood, switching to backup."
                         );
                         // update with default will choose which XvB to prefer. Will update XvB to use p2pool.
                         process_xvb.lock().unwrap().signal =
-                            ProcessSignal::UpdateNodes(XvbNode::default());
+                            ProcessSignal::UpdatePools(Pool::default());
                     }
-                    pub_api_xvb.lock().unwrap().current_node = node;
+                    pub_api_xvb.lock().unwrap().current_pool = node;
                 }
             }
             //			println!("{}", line); // For debugging.
@@ -129,6 +148,7 @@ impl Helper {
     pub fn build_xp_args(
         state: &crate::disk::state::XmrigProxy,
         mode: StartOptionsMode,
+        p2pool_stratum_port: u16,
     ) -> Vec<String> {
         let mut args = Vec::with_capacity(500);
         let api_ip;
@@ -152,15 +172,15 @@ impl Helper {
                     state.simple_rig.clone()
                 }; // Rig name
                 args.push("-o".to_string());
-                args.push("127.0.0.1:3333".to_string()); // Local P2Pool (the default)
+                args.push(format!("127.0.0.1:{p2pool_stratum_port}")); // Local P2Pool (the default)
                 args.push("-b".to_string());
-                args.push("0.0.0.0:3355".to_string());
+                args.push(format!("0.0.0.0:{}", PROXY_PORT_DEFAULT));
                 args.push("--user".to_string());
                 args.push(rig); // Rig name
                 args.push("--http-host".to_string());
                 args.push("127.0.0.1".to_string()); // HTTP API IP
                 args.push("--http-port".to_string());
-                args.push("18089".to_string()); // HTTP API Port
+                args.push(PROXY_API_PORT_DEFAULT.to_string()); // HTTP API Port
             }
             StartOptionsMode::Advanced => {
                 // XMRig doesn't understand [localhost]
@@ -175,18 +195,20 @@ impl Helper {
                     state.api_ip.to_string()
                 };
                 api_port = if state.api_port.is_empty() {
-                    "18089".to_string()
+                    PROXY_API_PORT_DEFAULT.to_string()
                 } else {
                     state.api_port.to_string()
                 };
-                ip = if state.api_ip == "localhost" || state.ip.is_empty() {
+                ip = if state.ip == "localhost" {
+                    "127.0.0.1".to_string()
+                } else if state.ip.is_empty() {
                     "0.0.0.0".to_string()
                 } else {
                     state.ip.to_string()
                 };
 
                 port = if state.port.is_empty() {
-                    "3355".to_string()
+                    PROXY_PORT_DEFAULT.to_string()
                 } else {
                     state.port.to_string()
                 };
@@ -221,6 +243,43 @@ impl Helper {
         args
     }
 
+    pub fn mutate_img_proxy(helper: &Arc<Mutex<Self>>, state: &crate::disk::state::XmrigProxy) {
+        if state.simple {
+            *helper.lock().unwrap().img_proxy.lock().unwrap() = ImgProxy::new();
+        } else if !state.arguments.is_empty() {
+            // This parses the input and attempts to fill out
+            // the [ImgXmrig]... This is pretty bad code...
+            let mut last = "";
+            let lock = helper.lock().unwrap();
+            let mut proxy_image = lock.img_proxy.lock().unwrap();
+            for arg in state.arguments.split_whitespace() {
+                match last {
+                    "--bind" | "-b" => {
+                        proxy_image.port = last
+                            .split(":")
+                            .last()
+                            .unwrap_or_default()
+                            .parse()
+                            .unwrap_or(PROXY_PORT_DEFAULT);
+                    }
+                    "--http-host" => {
+                        proxy_image.api_port = last.parse().unwrap_or(PROXY_API_PORT_DEFAULT)
+                    }
+                    l if l.contains("--http-access-token=") => {
+                        proxy_image.token = l.split_once("=").unwrap().1.to_string();
+                    }
+                    _ => {}
+                }
+                last = arg;
+            }
+        } else {
+            *helper.lock().unwrap().img_proxy.lock().unwrap() = ImgProxy {
+                api_port: state.api_port.parse().unwrap_or(PROXY_API_PORT_DEFAULT),
+                port: state.port.parse().unwrap_or(PROXY_PORT_DEFAULT),
+                token: state.token.clone(),
+            };
+        }
+    }
     pub fn stop_xp(helper: &Arc<Mutex<Self>>) {
         info!("XMRig-Proxy | Attempting to stop...");
         helper.lock().unwrap().xmrig_proxy.lock().unwrap().signal = ProcessSignal::Stop;
@@ -241,19 +300,16 @@ impl Helper {
     pub fn restart_xp(
         helper: &Arc<Mutex<Self>>,
         state: &crate::disk::state::XmrigProxy,
-        state_xmrig: &Xmrig,
+        state_p2pool: &P2pool,
         path: &Path,
     ) {
         info!("XMRig-Proxy | Attempting to restart...");
         helper.lock().unwrap().xmrig_proxy.lock().unwrap().state = ProcessState::Middle;
         helper.lock().unwrap().xmrig_proxy.lock().unwrap().signal = ProcessSignal::Restart;
 
-        let helper = Arc::clone(helper);
-        let state = state.clone();
-        let state_xmrig = state_xmrig.clone();
         let path = path.to_path_buf();
         // This thread lives to wait, start xmrig_proxy then die.
-        thread::spawn(move || {
+        thread::spawn(enc!((helper, state,  state_p2pool, path)move || {
             while helper.lock().unwrap().xmrig_proxy.lock().unwrap().state != ProcessState::Waiting
             {
                 warn!("XMRig-proxy | Want to restart but process is still alive, waiting...");
@@ -261,14 +317,14 @@ impl Helper {
             }
             // Ok, process is not alive, start the new one!
             info!("XMRig-Proxy | Old process seems dead, starting new one!");
-            Self::start_xp(&helper, &state, &state_xmrig, &path);
-        });
+            Self::start_xp(&helper, &state,  &state_p2pool, &path);
+        }));
         info!("XMRig-Proxy | Restart ... OK");
     }
     pub fn start_xp(
         helper: &Arc<Mutex<Self>>,
         state_proxy: &crate::disk::state::XmrigProxy,
-        state_xmrig: &Xmrig,
+        state_p2pool: &P2pool,
         path: &Path,
     ) {
         helper.lock().unwrap().xmrig_proxy.lock().unwrap().state = ProcessState::Middle;
@@ -280,7 +336,15 @@ impl Helper {
         } else {
             StartOptionsMode::Advanced
         };
-        let args = Self::build_xp_args(state_proxy, mode);
+
+        // get the stratum port of p2pool
+        let process_p2pool = Arc::clone(&helper.lock().unwrap().p2pool);
+        let p2pool_img = Arc::clone(&helper.lock().unwrap().img_p2pool);
+        let p2pool_stratum_port =
+            state_p2pool.current_port(&process_p2pool.lock().unwrap(), &p2pool_img.lock().unwrap());
+        // store the data used for startup to make it available to the other processes.
+        Helper::mutate_img_proxy(helper, state_proxy);
+        let args = Self::build_xp_args(state_proxy, mode, p2pool_stratum_port);
         // Print arguments & user settings to console
         crate::disk::print_dash(&format!("XMRig-Proxy | Launch arguments: {:#?}", args));
         info!("XMRig-Proxy | Using path: [{}]", path.display());
@@ -292,11 +356,11 @@ impl Helper {
         let process_xvb = Arc::clone(&helper.lock().unwrap().xvb);
         let process_xmrig = Arc::clone(&helper.lock().unwrap().xmrig);
         let path = path.to_path_buf();
-        let token = state_proxy.token.clone();
-        let state_xmrig = state_xmrig.clone();
-        let redirect_xmrig = state_proxy.redirect_local_xmrig;
+        let state = state_proxy.clone();
+        let state_p2pool = state_p2pool.clone();
         let pub_api_xvb = Arc::clone(&helper.lock().unwrap().pub_api_xvb);
         let pub_api_xmrig = Arc::clone(&helper.lock().unwrap().pub_api_xmrig);
+        let xmrig_img = Arc::clone(&helper.lock().unwrap().img_xmrig);
         thread::spawn(move || {
             Self::spawn_xp_watchdog(
                 &process,
@@ -304,13 +368,15 @@ impl Helper {
                 &pub_api,
                 args,
                 path,
-                &token,
-                &state_xmrig,
-                redirect_xmrig,
+                &state,
                 process_xvb,
                 process_xmrig,
                 &pub_api_xvb,
                 &pub_api_xmrig,
+                &xmrig_img,
+                process_p2pool,
+                &state_p2pool,
+                &p2pool_img,
             );
         });
     }
@@ -323,13 +389,15 @@ impl Helper {
         pub_api: &Arc<Mutex<PubXmrigProxyApi>>,
         args: Vec<String>,
         path: std::path::PathBuf,
-        token_proxy: &str,
-        state_xmrig: &Xmrig,
-        xmrig_redirect: bool,
+        state: &XmrigProxy,
         process_xvb: Arc<Mutex<Process>>,
         process_xmrig: Arc<Mutex<Process>>,
         pub_api_xvb: &Arc<Mutex<PubXvbApi>>,
         pub_api_xmrig: &Arc<Mutex<PubXmrigApi>>,
+        xmrig_img: &Arc<Mutex<ImgXmrig>>,
+        process_p2pool: Arc<Mutex<Process>>,
+        p2pool_state: &P2pool,
+        p2pool_img: &Arc<Mutex<ImgP2pool>>,
     ) {
         process.lock().unwrap().start = Instant::now();
         // spawn pty
@@ -348,9 +416,11 @@ impl Helper {
         let reader = pair.master.try_clone_reader().unwrap(); // Get STDOUT/STDERR before moving the PTY
         let output_parse = Arc::clone(&process.lock().unwrap().output_parse);
         let output_pub = Arc::clone(&process.lock().unwrap().output_pub);
-        spawn(enc!((pub_api_xvb, output_parse, output_pub) async move {
-            Self::read_pty_xp(output_parse, output_pub, reader, process_xvb, &pub_api_xvb).await;
-        }));
+        spawn(
+            enc!((pub_api_xvb, output_parse, output_pub, process_p2pool, p2pool_state, p2pool_img,  state) async move {
+                Self::read_pty_xp(output_parse, output_pub, reader, process_xvb, &pub_api_xvb, process_p2pool, &p2pool_state, &p2pool_img, &state).await;
+            }),
+        );
         // 1b. Create command
         debug!("XMRig-Proxy | Creating command...");
         let mut cmd = portable_pty::cmdbuilder::CommandBuilder::new(path.clone());
@@ -362,8 +432,11 @@ impl Helper {
         drop(pair.slave);
         let mut stdin = pair.master.take_writer().unwrap();
         // to refactor to let user use his own ports
-        let api_summary_xp = XMRIG_PROXY_SUMMARY_URL;
-        let api_config_xmrig = XMRIG_CONFIG_URL;
+        let api_summary_xp = format!(
+            "http://127.0.0.1:{}/{}",
+            state.api_port(),
+            XMRIG_API_SUMMARY_ENDPOINT
+        );
 
         // set state
         let client = client();
@@ -393,6 +466,8 @@ impl Helper {
             error!("XMRig-Proxy Watchdog | STDIN error: {}", e);
         }
         info!("XMRig-Proxy | Entering watchdog mode... woof!");
+        let mut last_redirect_request = Instant::now();
+        let mut first_loop = true;
         loop {
             let now = Instant::now();
             debug!("XMRig-Proxy Watchdog | ----------- Start of loop -----------");
@@ -435,12 +510,17 @@ impl Helper {
                     &output_parse,
                     start.elapsed(),
                     &mut process_lock,
+                    &process_p2pool.lock().unwrap(),
+                    p2pool_img,
+                    p2pool_state,
+                    state,
                 );
                 drop(pub_api_lock);
                 drop(process_lock);
                 // update data from api
                 debug!("XMRig-Proxy Watchdog | Attempting HTTP API request...");
-                match PrivXmrigProxyApi::request_xp_api(&client, api_summary_xp, token_proxy).await
+                match PrivXmrigProxyApi::request_xp_api(&client, &api_summary_xp, &state.token)
+                    .await
                 {
                     Ok(priv_api) => {
                         debug!(
@@ -456,18 +536,23 @@ impl Helper {
                     }
                 }
                 // update xmrig to use xmrig-proxy if option enabled and local xmrig alive
-                if xmrig_redirect
-                    && pub_api_xmrig.lock().unwrap().node != XvbNode::XmrigProxy.to_string()
+                // if the request was just sent, do not repeat it, let xmrig time to apply the change.
+                let pool = Pool::XmrigProxy(state.bind_port()); // get current port of xmrig-proxy
+                if (state.redirect_local_xmrig
+                    && pub_api_xmrig.lock().unwrap().pool.as_ref() != Some(&pool)
                     && (process_xmrig.lock().unwrap().state == ProcessState::Alive
-                        || process_xmrig.lock().unwrap().state == ProcessState::NotMining)
+                        || process_xmrig.lock().unwrap().state == ProcessState::NotMining))
+                    && (first_loop || last_redirect_request.elapsed() > Duration::from_secs(5))
                 {
+                    last_redirect_request = Instant::now();
                     info!("redirect local xmrig instance to xmrig-proxy");
-                    let node = XvbNode::XmrigProxy;
+                    let api_uri =
+                        current_api_url_xrig(true, Some(&xmrig_img.lock().unwrap()), None);
                     if let Err(err) = update_xmrig_config(
                         &client,
-                        api_config_xmrig,
-                        &state_xmrig.token,
-                        &node,
+                        &api_uri,
+                        &xmrig_img.lock().unwrap().token,
+                        &pool,
                         "",
                         GUPAX_VERSION_UNDERSCORE,
                     )
@@ -490,11 +575,37 @@ impl Helper {
             } // locked are dropped here
             // do not use more than 1 second for the loop
             sleep_end_loop(now, ProcessName::XmrigProxy).await;
+            if first_loop {
+                first_loop = false;
+            }
         }
 
         // 5. If loop broke, we must be done here.
         info!("XMRig-Proxy Watchdog | Watchdog thread exiting... Goodbye!");
         // sleep
+    }
+}
+//---------------------------------------------------------------------------------------------------- [ImgProxy]
+#[derive(Debug, Clone)]
+pub struct ImgProxy {
+    pub api_port: u16,
+    pub port: u16,
+    pub token: String,
+}
+
+impl Default for ImgProxy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImgProxy {
+    pub fn new() -> Self {
+        Self {
+            api_port: PROXY_API_PORT_DEFAULT,
+            port: PROXY_PORT_DEFAULT,
+            token: String::new(),
+        }
     }
 }
 #[allow(unused)]
@@ -511,7 +622,7 @@ pub struct PubXmrigProxyApi {
     pub hashrate_12h: f32,
     pub hashrate_24h: f32,
     pub miners: u16,
-    pub node: String,
+    pub pool: Option<Pool>,
 }
 
 impl Default for PubXmrigProxyApi {
@@ -533,15 +644,20 @@ impl PubXmrigProxyApi {
             hashrate_12h: 0.0,
             hashrate_24h: 0.0,
             miners: 0,
-            node: UNKNOWN_DATA.to_string(),
+            pool: None,
         }
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn update_from_output(
         public: &mut Self,
         output_parse: &Arc<Mutex<String>>,
         output_pub: &Arc<Mutex<String>>,
         elapsed: std::time::Duration,
         process: &mut Process,
+        process_p2pool: &Process,
+        p2pool_img: &Arc<Mutex<ImgP2pool>>,
+        p2pool_state: &P2pool,
+        state: &XmrigProxy,
     ) {
         // 1. Take the process's current output buffer and combine it with Pub (if not empty)
         let mut output_pub = output_pub.lock().unwrap();
@@ -562,15 +678,19 @@ impl PubXmrigProxyApi {
         {
             process.state = ProcessState::Alive;
             // get the pool we mine on to put it on stats
-            if let Some(name_pool) = crate::regex::detect_node_xmrig(&output_parse) {
-                public.node = name_pool;
+            if let Some(name_pool) = detect_pool_xmrig(
+                &output_parse,
+                state.bind_port(),
+                p2pool_state.current_port(process_p2pool, &p2pool_img.lock().unwrap()),
+            ) {
+                public.pool = Some(name_pool);
             }
         } else if XMRIG_REGEX.timeout.is_match(&output_parse)
             || XMRIG_REGEX.invalid_conn.is_match(&output_parse)
             || XMRIG_REGEX.error.is_match(&output_parse)
         {
             process.state = ProcessState::NotMining;
-            public.node = NO_POOL.to_string();
+            public.pool = None;
         }
         // 3. Throw away [output_parse]
         output_parse.clear();

--- a/src/helper/xvb/priv_stats.rs
+++ b/src/helper/xvb/priv_stats.rs
@@ -36,7 +36,7 @@ use crate::{
     helper::{Process, ProcessName, ProcessState, xvb::output_console},
 };
 
-use super::{PubXvbApi, nodes::XvbNode, rounds::XvbRound};
+use super::{PubXvbApi, nodes::Pool, rounds::XvbRound};
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 pub enum RuntimeMode {
@@ -78,11 +78,11 @@ pub struct XvbPrivStats {
     #[serde(skip)]
     pub round_participate: Option<XvbRound>,
     #[serde(skip)]
-    pub node: XvbNode,
+    pub pool: Pool,
     #[serde(skip)]
     // it is the time remaining before switching from P2pool to XvB or XvB to P2ool.
     // it is not the time remaining of the algo, even if it could be the same if never mining on XvB.
-    pub time_switch_node: u32,
+    pub time_switch_pool: u32,
     #[serde(skip)]
     pub msg_indicator: String,
     #[serde(skip)]

--- a/src/inits.rs
+++ b/src/inits.rs
@@ -1,4 +1,6 @@
-use crate::components::update::{Update, check_binary_path};
+#[cfg(not(feature = "distro"))]
+use crate::components::update::Update;
+use crate::components::update::check_binary_path;
 use crate::errors::process_running;
 use crate::helper::{Helper, ProcessName, ProcessSignal};
 use crate::utils::constants::{
@@ -202,12 +204,12 @@ pub fn init_auto(app: &mut App) {
                 "Gupaxx | P2pool instance is already running outside of Gupaxx ! Skipping auto-node..."
             );
         } else {
-            let backup_hosts = app.gather_backup_hosts();
             Helper::start_p2pool(
                 &app.helper,
                 &app.state.p2pool,
+                &app.state.node,
                 &app.state.gupax.absolute_p2pool_path,
-                backup_hosts,
+                app.backup_hosts.clone(),
                 false,
             );
         }
@@ -234,6 +236,8 @@ pub fn init_auto(app: &mut App) {
             Helper::start_xmrig(
                 &app.helper,
                 &app.state.xmrig,
+                &app.state.p2pool,
+                &app.state.xmrig_proxy,
                 &app.state.gupax.absolute_xmrig_path,
                 Arc::clone(&app.sudo),
             );
@@ -263,7 +267,7 @@ pub fn init_auto(app: &mut App) {
             Helper::start_xp(
                 &app.helper,
                 &app.state.xmrig_proxy,
-                &app.state.xmrig,
+                &app.state.p2pool,
                 &app.state.gupax.absolute_xp_path,
             );
         }

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -92,14 +92,8 @@ pub const P2POOL_API_PATH_NETWORK: &str = "network/stats";
 pub const P2POOL_API_PATH_POOL: &str = "pool/stats";
 #[cfg(target_family = "unix")]
 pub const P2POOL_API_PATH_P2P: &str = "local/p2p";
-pub const XMRIG_API_SUMMARY_URI: &str = "1/summary"; // The default relative URI of XMRig's API summary
-// pub const XMRIG_API_CONFIG_URI: &str = "1/config"; // The default relative URI of XMRig's API config
-// todo allow user to change the port of the http api for xmrig and xmrig-proxy
-pub const XMRIG_CONFIG_URL: &str = "http://127.0.0.1:18088/1/config"; // The default relative URI of XMRig's API config
-pub const XMRIG_PROXY_CONFIG_URL: &str = "http://127.0.0.1:18089/1/config"; // The default relative URI of XMRig Proxy's API config
-pub const XMRIG_SUMMARY_URL: &str = "http://127.0.0.1:18088/1/summary"; // The default relative URI of XMRig's API config
-pub const XMRIG_PROXY_SUMMARY_URL: &str = "http://127.0.0.1:18089/1/summary"; // The default relative URI of XMRig Proxy's API config
-pub const NO_POOL: &str = "Not connected to any pool"; // status tab xrig if no pool is used
+pub const XMRIG_API_SUMMARY_ENDPOINT: &str = "1/summary"; // The default relative URI of XMRig's API summary
+pub const XMRIG_API_CONFIG_ENDPOINT: &str = "1/config"; // The default relative URI of XMRig's API config
 
 // Process state tooltips (online, offline, etc)
 pub const P2POOL_ALIVE: &str = "P2Pool is online and fully synchronized";
@@ -148,9 +142,9 @@ pub const STATUS_XMRIG_PROXY_POOL: &str = "The pool XMRig-Proxy is currently min
 pub const STATUS_XMRIG_PROXY_HASHRATE: &str = "The average hashrate of XMRig-Proxy";
 
 pub const XVB_ALIVE: &str =
-    "XvB process is configured and distributing hashrate, XvB node is online";
+    "XvB process is configured and distributing hashrate, XvB pool is online";
 pub const XVB_DEAD: &str = "XvB process is offline";
-pub const XVB_FAILED: &str = "XvB process is misconfigured or the XvB node is offline";
+pub const XVB_FAILED: &str = "XvB process is misconfigured or the XvB pool is offline";
 pub const XVB_MIDDLE: &str = "XvB is in the middle of (re)starting/stopping";
 pub const XVB_NOT_CONFIGURED: &str = "You need to insert an existent token before starting XvB";
 pub const XVB_PUBLIC_ONLY: &str = "XvB process is started only to get public stats.";
@@ -383,6 +377,7 @@ pub const GUPAX_PATH_XMRIG: &str = "The location of the XMRig binary: Both absol
 pub const GUPAX_PATH_XMRIG_PROXY: &str = "The location of the XMRig-Proxy binary: Both absolute and relative paths are accepted; A red [X] will appear if there is no file found at the given path";
 
 // P2Pool
+pub const P2POOL_PORT_DEFAULT: u16 = 3333;
 pub const P2POOL_MAIN: &str = "Use the P2Pool main-chain. This P2Pool finds blocks faster, but has a higher difficulty. Suitable for miners with more than 50kH/s";
 pub const P2POOL_MINI: &str = "Use the P2Pool mini-chain. This P2Pool finds blocks slower, but has a lower difficulty. Suitable for miners with less than 50kH/s";
 pub const P2POOL_OUT: &str = "How many out-bound peers to connect to? (you connecting to others)";
@@ -444,6 +439,8 @@ pub const LIST_SAVE: &str = "Save the current values to the already existing ent
 pub const LIST_DELETE: &str = "Delete the currently selected entry";
 pub const LIST_CLEAR: &str = "Clear all current values";
 // Node
+pub const NODE_RPC_PORT_DEFAULT: u16 = 18081;
+pub const NODE_ZMQ_PORT_DEFAULT: u16 = 18083;
 pub const NODE_INPUT: &str = "Send a command to Node";
 pub const NODE_PRUNNING: &str = "Reduce the database size to a third. Does not have any security/privacy impact.If you have enough storage, a full node is preferable to make the network even more decentralized.";
 #[cfg(not(windows))]
@@ -480,6 +477,7 @@ pub const NODE_API_PORT: &str = "RPC API listen port";
 pub const NODE_ZMQ_BIND: &str = "bind address of ZMQ API";
 pub const NODE_ZMQ_PORT: &str = "ZMQ API listen port";
 // XMRig
+pub const XMRIG_API_PORT_DEFAULT: u16 = 18088;
 pub const XMRIG_SIMPLE: &str = r#"Use simple XMRig settings:
   - Mine to local P2Pool (localhost:3333)
   - CPU thread slider
@@ -517,6 +515,8 @@ pub const XMRIG_PATH_NOT_VALID: &str = "XMRig binary at the given PATH in the Gu
 pub const XMRIG_PATH_OK: &str = "XMRig was found at the given PATH";
 pub const XMRIG_PATH_EMPTY: &str = "XMRig PATH is empty! To fix: goto the [GupaxxAdvanced] tab, select [Open] and specify where XMRig is located.";
 pub const XMRIG_PROXY_URL: &str = "https://github.com/xmrig/xmrig-proxy";
+pub const PROXY_API_PORT_DEFAULT: u16 = 18089;
+pub const PROXY_PORT_DEFAULT: u16 = 3355;
 
 // XvB
 pub const XVB_HELP: &str = "You need to register an account by clicking on the link above to get your token with the same p2pool XMR address you use for payment.";
@@ -559,6 +559,9 @@ pub const XVB_ROUND_DONOR_VIP_MIN_HR: u32 = 10000;
 pub const XVB_ROUND_DONOR_WHALE_MIN_HR: u32 = 100000;
 pub const XVB_ROUND_DONOR_MEGA_MIN_HR: u32 = 1000000;
 
+// Common help
+pub const HELP_STRATUM_PORT: &str = "Specify the stratum port to bind to";
+pub const HELP_STRATUM_IP: &str = "Specify the stratum ip to bind to";
 // Manual Mode
 pub const XVB_MODE_MANUAL_XVB_HELP: &str = "Manually set the amount to donate to XmrVsBeast, If value is more than xmrig hashrate it might be changed";
 pub const XVB_MODE_MANUAL_P2POOL_HELP: &str = "Manually set the amount to keep on P2pool, If value is more than xmrig hashrate it might be changed";


### PR DESCRIPTION
feat: add fields for p2pool port, token for xmrig,  token/ip/port for proxy
feat: no need for restarting service that depends on other when the orher service is restarted with new settings
feat: custom args reflects edited fields of other processes feat: rename "node" appearance to "pool" when it means the latter feat: detect and print in status custom pool
fix: proxy was setting bind to 0.0.0.0 if localhost name was used fix: generate backup hosts only once at start