### PR TITLE
feat: light/dark mode (not fully yet)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,7 +46,8 @@ use crate::inits::init_text_styles;
 use crate::miscs::cmp_f64;
 use crate::miscs::get_exe;
 use crate::miscs::get_exe_dir;
-use crate::utils::constants::VISUALS;
+use crate::utils::constants::VISUALS_DARK;
+use crate::utils::constants::VISUALS_LIGHT;
 use crate::utils::macros::arc_mut;
 use crate::utils::sudo::SudoState;
 use derive_more::derive::Display;
@@ -83,6 +84,7 @@ pub struct App {
     // Misc state
     pub tab: Tab,   // What tab are we on?
     pub size: Vec2, // Top-level width and Top-level height
+    pub dark_mode: bool, // to switch between dark/white
     // Alpha (transparency)
     // This value is used to incrementally increase/decrease
     // the transparency when resizing. Basically, it fades
@@ -179,10 +181,17 @@ impl App {
             &cc.egui_ctx,
             crate::miscs::clamp_scale(app.state.gupax.selected_scale),
         );
-        cc.egui_ctx.set_visuals(VISUALS.clone());
+
+        Self::set_theme(&app, cc);
         Self { resolution, ..app }
     }
-
+    pub fn set_theme(app: &Self, cc: &CreationContext<'_>) {
+        if app.dark_mode {
+            cc.egui_ctx.set_visuals(VISUALS_DARK.clone());
+        } else {
+            cc.egui_ctx.set_visuals(VISUALS_LIGHT.clone());
+        }
+    }
     #[cold]
     #[inline(never)]
     pub fn save_before_quit(&mut self) {
@@ -239,6 +248,7 @@ impl App {
         let ip_local = arc_mut!(None);
         let ip_public = arc_mut!(None);
         let proxy_port_reachable = arc_mut!(false);
+        let dark_mode = true; 
 
         info!("App Init | Sysinfo...");
         // We give this to the [Helper] thread.
@@ -314,6 +324,7 @@ impl App {
                 ip_public.clone(),
                 proxy_port_reachable.clone(),
             )),
+            dark_mode,
             node,
             p2pool,
             xmrig,

--- a/src/app/panels/bottom.rs
+++ b/src/app/panels/bottom.rs
@@ -60,6 +60,8 @@ impl crate::app::App {
                             self.version(ui, bar_height);
                             ui.add(Separator::default().grow(extra_separator));
                             self.os_show(ui);
+                            ui.add(Separator::default().grow(extra_separator));
+                            self.theme_show(ui);
                             // width of each status
                             let width_status = if !tiny_width {
                                 ((ui.available_width()
@@ -135,6 +137,15 @@ impl crate::app::App {
         }
         #[cfg(target_family = "unix")]
         ui.label(self.os);
+    }
+    fn theme_show(&mut self, ui: &mut Ui) {
+        let text = if self.dark_mode {"🌙" } else {"🌞"};
+        
+        if ui
+            .add(Button::new(text))
+            .clicked() {
+                self.dark_mode = !self.dark_mode;
+            }
     }
     fn status_process(process: &ProcessStateGui, ui: &mut Ui, width: f32) {
         let color;

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -606,7 +606,7 @@ pub const ACCENT_COLOR: Color32 = Color32::from_rgb(200, 100, 100);
 pub const BG: Color32 = Color32::from_gray(20);
 
 // This is based off [`Visuals::dark()`].
-pub static VISUALS: Lazy<Visuals> = Lazy::new(|| {
+pub static VISUALS_DARK: Lazy<Visuals> = Lazy::new(|| {
     let selection = Selection {
         bg_fill: ACCENT_COLOR,
         stroke: Stroke::new(1.0, Color32::from_gray(255)),
@@ -671,6 +671,72 @@ pub static VISUALS: Lazy<Visuals> = Lazy::new(|| {
         window_shadow: Shadow::NONE,
         popup_shadow: Shadow::NONE,
         ..Visuals::dark()
+    }
+});
+// Light mode version of [`Visuals::dark()`] → based on `Visuals::light()`
+pub static VISUALS_LIGHT: Lazy<Visuals> = Lazy::new(|| {
+    let selection = Selection {
+        bg_fill: ACCENT_COLOR, // keep accent the same
+        stroke: Stroke::new(1.0, Color32::from_gray(200)),
+    };
+
+    // Adapted from default light() in egui 0.24.1
+    let widgets = Widgets {
+        noninteractive: WidgetVisuals {
+            bg_fill: Color32::WHITE,
+            bg_stroke: Stroke::new(1.0, Color32::from_gray(200)), // light separators
+            fg_stroke: Stroke::new(1.0, Color32::from_gray(80)),  // normal text
+            corner_radius: CornerRadius::same(10),
+            expansion: 0.0,
+            weak_bg_fill: Color32::WHITE,
+        },
+        inactive: WidgetVisuals {
+            bg_fill: Color32::from_gray(240),
+            bg_stroke: Default::default(),
+            fg_stroke: Stroke::new(1.0, Color32::from_gray(100)), // button text
+            corner_radius: CornerRadius::same(10),
+            expansion: 0.0,
+            weak_bg_fill: Color32::from_gray(240),
+        },
+        hovered: WidgetVisuals {
+            bg_fill: Color32::from_gray(225),
+            bg_stroke: Stroke::new(1.0, Color32::from_gray(150)),
+            fg_stroke: Stroke::new(1.5, Color32::from_gray(0)),
+            corner_radius: CornerRadius::same(10),
+            expansion: 1.0,
+            weak_bg_fill: Color32::from_gray(225),
+        },
+        active: WidgetVisuals {
+            bg_fill: Color32::from_gray(210),
+            bg_stroke: Stroke::new(1.0, Color32::from_gray(0)),
+            fg_stroke: Stroke::new(2.0, Color32::from_gray(0)),
+            corner_radius: CornerRadius::same(10),
+            expansion: 1.0,
+            weak_bg_fill: Color32::from_gray(180),
+        },
+        open: WidgetVisuals {
+            bg_fill: Color32::from_gray(245),
+            bg_stroke: Stroke::new(1.0, Color32::from_gray(200)),
+            fg_stroke: Stroke::new(1.0, Color32::from_gray(60)),
+            corner_radius: CornerRadius::same(10),
+            expansion: 0.0,
+            weak_bg_fill: Color32::from_gray(230),
+        },
+    };
+
+    Visuals {
+        widgets,
+        selection,
+        hyperlink_color: Color32::from_rgb(0, 102, 204),            // deeper blue for contrast
+        faint_bg_color: Color32::from_additive_luminance(250),      // barely off-white
+        extreme_bg_color: Color32::from_gray(245),                  // e.g. TextEdit bg
+        code_bg_color: Color32::from_gray(230),
+        warn_fg_color: Color32::from_rgb(200, 100, 0),              // muted orange
+        error_fg_color: Color32::from_rgb(200, 0, 0),               // muted red
+        window_corner_radius: CornerRadius::same(6),
+        window_shadow: Shadow::NONE,
+        popup_shadow: Shadow::NONE,
+        ..Visuals::light()
     }
 });
 //---------------------------------------------------------------------------------------------------- CONSTANTS


### PR DESCRIPTION
## Summary

This PR tries to solve #90, adds a user-toggleable Dark/Light mode to the application (not working 100% yet).   

* A new `dark_mode: bool` state variable, controlled by a button.

## Questions

* Is there a more “canonical” way in `eframe` to switch themes at runtime without restarting the application with the theme already setup? I did this below, but we need to find a way to change while the program is running:

```rust
    pub fn set_theme(app: &Self, cc: &CreationContext<'_>) {
        if app.dark_mode {
            cc.egui_ctx.set_visuals(VISUALS_DARK.clone());
        } else {
            cc.egui_ctx.set_visuals(VISUALS_LIGHT.clone());
        }
    }
 ```


---


![image](https://github.com/user-attachments/assets/519708f4-dcf4-451b-a584-edb73520f6ad)


![image](https://github.com/user-attachments/assets/1b848e3f-7234-496c-b611-637c6f45f002)


