### PR TITLE
Fix: WMIC is deprecated in Win10-Win11/Windows Sever 2021+

### DIFF
--- a/src/helper/xrig/xmrig.rs
+++ b/src/helper/xrig/xmrig.rs
@@ -642,9 +642,24 @@ impl Helper {
                 && status.success()
             {
                 info!("Xmrig | wmic command successful")
+            }
+            // Fallback to PowerShell (Windows 7+)
+            else if let Ok(mut child) = std::process::Command::new("powershell")
+                .creation_flags(0x08000000)
+                .args([
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    "Get-Process -Name xmrig -ErrorAction SilentlyContinue | ForEach-Object { $_.PriorityClass = 'BelowNormal' }"
+                ])
+                .spawn()
+                && let Ok(status) = child.wait()
+                && status.success()
+            {
+                info!("Xmrig | PowerShell command successful");
             } else {
                 warn!(
-                    "Xmrig | wmic command unsuccessful, you might experience freeze with xmrig taking all the cpu time."
+                    "Xmrig | Unable to set priority. You might experience the GUI freezing with xmrig taking all the cpu time."
                 )
             }
         }


### PR DESCRIPTION
WMIC is deprecated as of Windows 10, version 21H1; and as of the 21H1 semi-annual channel release of Windows Server. This utility is superseded by Windows PowerShell for WMI. On Windows 11 24H2, it was removed (although optionally available) and completely removed for 25H2.

See: 

https://support.microsoft.com/en-au/topic/windows-management-instrumentation-command-line-wmic-removal-from-windows-e9e83c7f-4992-477f-ba1d-96f694b8665d

https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmic

While using Get-CimInstance is the recommended method to replace WMIC, in this specific case of changing the priority of the process, Get-Process is simpler and more direct and also doesn't require PowerShell 3.0.

So this fix adds fallback code to use the PowerShell cmdlet GetProcess to lower XMRig process priority to BelowNormal in the same way WMIC was used so that it doesn't take up all the CPU and cause Gupaxx to become non-responsive